### PR TITLE
Fix warning 'TypeError: commenter is null' due to comment preview

### DIFF
--- a/includes/bugzilla.js
+++ b/includes/bugzilla.js
@@ -6,7 +6,7 @@
 var settings = [],
     settings_fields = [],
     bug_id = false,
-    bz_comments = $('.bz_comment_text'),
+    bz_comments = $('.bz_comment_text:not(#comment_preview_text)'),
     already_run = [],
     total_new = 0,
     is_mozilla_theme;


### PR DESCRIPTION
The new comment preview feature also matched the selector used for `bz_comments`.