### PR TITLE
fix comment div alignment nits

### DIFF
--- a/includes/style.css
+++ b/includes/style.css
@@ -147,6 +147,10 @@ span.reporter {
     width: 677px;
 }
 
+.bz_first_comment_head, .bz_comment_head {
+    margin-left:0px;
+}
+
 .git_style .bz_first_comment,
 .git_style .no-first-comment .bz_comment {
     margin-left:0;
@@ -197,12 +201,6 @@ span.reporter {
     border-bottom:1px solid #CCCCCC;
     margin:0;
     padding:10px;
-    width:655px;
-}
-
-.git_style .bz_first_comment .bz_comment_text,
-.git_style .no-first-comment .bz_comment_text {
-    width:670px;
 }
 
 .git_style .bz_comment_user {


### PR DESCRIPTION
Override the negative margin on comment headers to restore padding all the way around the element.
Remove width restrictions on comment inner divs that did not apply to outer divs.

Takes this:
![before](https://cloud.githubusercontent.com/assets/21467/5923524/2296e576-a609-11e4-85c8-f415f9275f11.png)

To this:
![after](https://cloud.githubusercontent.com/assets/21467/5923528/2515e6bc-a609-11e4-9108-cf14ae9a573a.png)

