### PR TITLE
Fixes #101 - Add support for treeherder

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ These pertain to editing bugs.
 - Don't guess OS and hardware
 - Add a "new" link for dependent and blocking fields
 - Add a "browse" link for component fields
-- Show inline TBPL results
+- Show inline TBPL & treeherder results
 
 ## Listing Pages
 These modify parts of the pages with lists of bugs.

--- a/build.json
+++ b/build.json
@@ -22,7 +22,8 @@
         "bugzilla-misc.js",
         "bugzilla-agile.js",
         "bugzilla-keyboard.js",
-        "bugzilla-tbpl.js"
+        "bugzilla-tbpl.js",
+        "bugzilla-treeherder.js"
     ],
     "version": "3.3",
     "included_urls": "prefs.prefs.urls.split(/\\s*,\\s*/)",

--- a/includes/bugzilla-treeherder.js
+++ b/includes/bugzilla-treeherder.js
@@ -1,0 +1,56 @@
+'use strict';
+
+/* global registerPref, ifBug, settings */
+
+registerPref('show_treeherder', {'title': 'Show inline Treeherder results',
+                                 'setting_default': true,
+                                 'callback': ifBug(initTreeherder),
+                                 'category': 'bug'});
+
+function initTreeherder() {
+    if (!settings.show_treeherder) {
+        return;
+    }
+
+    document.addEventListener('focus', detectIframeFocused);
+    document.addEventListener('blur', detectIframeFocused);
+
+    var baseHref = 'https://treeherder.mozilla.org/embed/resultset-status/';
+    var selector = '.bz_comment_text a[href^="https://treeherder.mozilla.org/#/jobs?"]';
+    var treeherders = document.querySelectorAll(selector);
+
+    for (var i = 0, il = treeherders.length; i < il; i++) {
+        var treeherder = treeherders[i];
+        var href = treeherder.href;
+        var repo = href.match(/[&?]repo=([\w-]+)/);
+        var revision = href.match(/[&?]revision=([\w-]+)/);
+
+        if (!repo || !revision) {
+            return;
+        }
+
+        var iframe = document.createElement('iframe');
+        iframe.src = baseHref + repo[1] + '/' + revision[1] + '/';
+        iframe.classList.add('treeherder_inline_result');
+
+        treeherder.parentNode.appendChild(iframe);
+    }
+}
+
+// TODO : https://github.com/gkoberger/BugzillaJS/issues/69
+// Once dropping Ominum, do this more properly by including a script in
+// the iframes
+function detectIframeFocused() {
+    var iframes = document.getElementsByClassName('iframe_focused');
+    if (iframes.length) {
+        iframes[0].classList.remove('iframe_focused');
+    }
+
+    // We need a timeout here, otherwise document.activeElement has not
+    // changed yet
+    setTimeout(function() {
+        if (document.activeElement.nodeName.toLowerCase() == 'iframe') {
+            document.activeElement.classList.add('iframe_focused');
+        }
+    }, 0);
+}

--- a/includes/style.css
+++ b/includes/style.css
@@ -756,11 +756,16 @@ color:#fff;
      width: 0;
 }
 
-.tbpl_inline_result {
+.tbpl_inline_result,
+.treeherder_inline_result {
   width: 100%;
   border: 1px solid #ddd;
   background-color: white;
   height: 200px;
+}
+
+.treeherder_inline_result {
+  height: 60px;
 }
 
 .iframe_focused {


### PR DESCRIPTION
The header looks fairly plain but it is really up to the treeherder guys to fix that... still, better than nothing:
![Header](http://i.imgur.com/3Lc7rxo.png)

It does look good when one of the items is clicked:
![clicked](http://i.imgur.com/zAn510T.png)

There is no option to go back within treeherder but users can use backspace or the context menu to go back. Again, fixing this would be up to the treeherder guys.