### PR TITLE
Fix for the "Highlight reporter and assignee comments" broken feature

### DIFF
--- a/includes/bugzilla-comments.js
+++ b/includes/bugzilla-comments.js
@@ -17,17 +17,8 @@ function initHighlightRA() {
         return;
     }
 
-    var selector = '#bz_assignee_edit_container .vcard .fn';
-    var assignee = document.querySelector(selector).textContent;
-
-    var reporter = false;
-    for (var field of document.querySelectorAll('.field_label')) {
-        if (field.textContent.includes('Reported')) {
-            reporter = field.nextElementSibling.querySelector('.vcard .fn').
-                textContent;
-            break;
-        }
-    }
+	var assignee = $( "tr > th:contains('Assigned To')").next().find('.fn').html();
+    var reporter = $( ".field_label:contains('Reported:')").next().find('.fn').html();
 
     bz_comments.each(function(i, comment) {
         var commenter = comment.parentNode.querySelector('.vcard .fn');


### PR DESCRIPTION
This change makes the `Highlight reporter and assignee comments` feature work 
even if you don't have permission to edit the assignee field, or even if you haven't login to your bugzilla account.
Fixes #105.