### PR TITLE
Fix things to work with the new UI

### DIFF
--- a/includes/bugzilla-images.js
+++ b/includes/bugzilla-images.js
@@ -31,7 +31,7 @@ function initImageBoth() {
     }
     imageBothRun = true;
 
-    $('#attachment_table tr').each(function() {
+    $('#attachment_table tr, #attachments tr').each(function() {
         var $this = $(this);
         if ($this.prop('class').match('image')) {
             var $a = $this.find('a b').parent();
@@ -106,7 +106,7 @@ function initImageLightbox() {
     /* Close on <esc> */
     $(window).bind('close', closeLightbox);
 
-    $('#attachment_table, .bz_comment_table').delegate('.is-image',
+    $('#attachment_table, .bz_comment_table, #bugzilla-body').delegate('.is-image',
         'click', bzLightbox);
 }
 

--- a/includes/bugzilla-treeherder.js
+++ b/includes/bugzilla-treeherder.js
@@ -16,8 +16,8 @@ function initTreeherder() {
     document.addEventListener('blur', detectIframeFocused);
 
     var baseHref = 'https://treeherder.mozilla.org/embed/resultset-status/';
-    var selector = '.bz_comment_text ';
-    selector += 'a[href^="https://treeherder.mozilla.org/#/jobs?"]';
+    var a_selector = 'a[href^="https://treeherder.mozilla.org/#/jobs?"]';
+    var selector = `.bz_comment_text ${a_selector}, .comment-text ${a_selector}`;
     var treeherders = document.querySelectorAll(selector);
 
     for (var i = 0, il = treeherders.length; i < il; i++) {

--- a/includes/bugzilla.js
+++ b/includes/bugzilla.js
@@ -6,7 +6,7 @@
 var settings = [],
     settings_fields = [],
     bug_id = false,
-    bz_comments = $('.bz_comment_text:not(#comment_preview_text)'),
+    bz_comments = $('.bz_comment_text:not(#comment_preview_text), .comment-text:not(#comment-preview)'),
     already_run = [],
     total_new = 0,
     is_mozilla_theme;


### PR DESCRIPTION
The new bugzilla "modal" UI changes a few IDs and CSS classes. This changeset makes BugzillaJS aware of them.

Note: I've done some light testing to make sure that these changes work in both the new and old UIs; however, I can't say I've been exhaustive. That being said, the only feature I really care about is having inline treeherder logs. Given that, if there are any concerns about other parts of this patch, I would appreciate being able to push at least that change (which I have tested to work in both configurations).
